### PR TITLE
fix qpllport num calculation

### DIFF
--- a/src/main/scala/spinalutils/xilinx/ip/aurora/Aurora8b10b.scala
+++ b/src/main/scala/spinalutils/xilinx/ip/aurora/Aurora8b10b.scala
@@ -169,7 +169,7 @@ protected case class QPLLPort(incore: Boolean = false, locs: List[LaneLoc]) exte
   var parts: Set[Int] = Set()
   locs.foreach(f => {
     if (f.setValue != "X") {
-      parts += f.postion / 4 + 1
+      parts += scala.math.ceil(f.postion.toDouble / 4).toInt
     }
   })
 


### PR DESCRIPTION
fix qpllport.
For example, 16 should be 4. The previous edition is 5.